### PR TITLE
solve mosquitto configuration file problem

### DIFF
--- a/raspberry_pi/mqtt-install.sh
+++ b/raspberry_pi/mqtt-install.sh
@@ -11,6 +11,6 @@ sudo mosquitto_passwd -b -c /etc/mosquitto/passwd $USERNAME $PASS
 
 echo "listener 1883
 allow_anonymous false
-password_file /etc/mosquitto/passwd" | sudo tee -a /etc/mosquitto/mosquitto.conf
+password_file /etc/mosquitto/passwd" | sudo tee /etc/mosquitto/conf.d/local.conf
 
 sudo systemctl restart mosquitto


### PR DESCRIPTION
Now we don't add additional configurations to the main configuration file, but create personal configuration file in specialized directory.