### PR TITLE
add python library reqs

### DIFF
--- a/raspberry_pi/install.sh
+++ b/raspberry_pi/install.sh
@@ -14,7 +14,7 @@ sudo -u homeassistant -H -s bash -c "source bin/activate &&
         pip3 install wheel~=0.37"
         
 sudo -u homeassistant -H -s bash -c "source bin/activate &&
-				     pip3 install sqlalchemy~=1.4 fnvhash~=0.1"
+				     pip3 install sqlalchemy~=1.4 fnvhash~=0.1 aiodiscover==1.4.11"
 
 sudo -u homeassistant -H -s bash -c "source bin/activate &&
 				     pip3 install homeassistant==2022.8.2 && 

--- a/raspberry_pi/prebuild_install.sh
+++ b/raspberry_pi/prebuild_install.sh
@@ -14,7 +14,7 @@ sudo -u homeassistant -H -s bash -c "source bin/activate &&
         pip3 install wheel~=0.37"
         
 sudo -u homeassistant -H -s bash -c "source bin/activate &&
-				     pip3 install sqlalchemy~=1.4 fnvhash~=0.1"
+				     pip3 install sqlalchemy~=1.4 fnvhash~=0.1 aiodiscover==1.4.11"
 
 sudo -u homeassistant -H -s bash -c "source bin/activate &&
 				     pip3 install homeassistant==2022.8.2 && 


### PR DESCRIPTION
add python library to requirements in a way to avoid dhtp error in HomeAssistant.